### PR TITLE
Implement simple Flask portfolio analysis

### DIFF
--- a/Dashboard.py
+++ b/Dashboard.py
@@ -115,10 +115,15 @@ if check_password():
         if(value == 'Newsapi'):
             input = st.text_input(
                 'Enter What you have to Search for', 'stock in news')
-            top_headlines = newsapi.get_everything(q=str(input))
-            for headline in top_headlines['articles']:
-                st.write("Title : " + headline['title'])
-                st.write("Description: " + headline['url'])
+            try:
+                top_headlines = newsapi.get_everything(q=str(input))
+            except Exception as e:
+                st.error(f"News API request failed: {e}")
+                top_headlines = {"articles": []}
+
+            for headline in top_headlines.get('articles', []):
+                st.write("Title : " + headline.get('title', ''))
+                st.write("Description: " + headline.get('url', ''))
         elif(value == 'Google Search'):
             input = st.text_input(
             'Enter What you have to Search for', 'stock in news')

--- a/Readme.md
+++ b/Readme.md
@@ -1,12 +1,20 @@
 # hedgeFundApp
- Experimental Test For Wealth Management
+Experimental Test For Wealth Management
 This is demo version of Wealth Management Dashboard for Portfolio Managers
 
-#environment creation
-    1. cd envenv
-    2.Scripts\activate
-    3. pip3 freeze > requirementsWin.txt
-    4. streamlit run Dashboard.py
+## Environment setup
+1. `python -m venv venv`
+2. `source venv/bin/activate` (or `venv\Scripts\activate` on Windows)
+3. `pip install -r requirements.txt`
+4. `streamlit run Dashboard.py`
 
-# The aim of this Project is to provide detail analysis of stock news for the users so that he can make timely decision in order to manage his portfolio well.
-    1.Requirements that we think would help 
+The aim of this project is to provide detailed analysis of stock news for the users so that they can make timely decisions in order to manage portfolios well.
+
+## Flask portfolio analysis
+A simple Flask application is included in `app.py`. Start it with:
+
+```bash
+python app.py
+```
+
+Send a POST request to `/analyze` with a JSON payload containing a list of `tickers`, optional `weights`, and a `benchmark` symbol. The service downloads historical prices using `yfinance` and returns portfolio metrics compared to the benchmark.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,62 @@
+from flask import Flask, request, jsonify
+import pandas as pd
+import yfinance as yf
+import numpy as np
+
+app = Flask(__name__)
+
+
+def compute_metrics(prices: pd.Series):
+    returns = prices.pct_change().dropna()
+    cumulative_return = (1 + returns).prod() - 1
+    volatility = returns.std() * np.sqrt(252)
+    sharpe = (returns.mean() / returns.std()) * np.sqrt(252)
+    return cumulative_return, volatility, sharpe
+
+
+@app.route("/")
+def index():
+    return "Portfolio Analysis API"
+
+
+@app.route("/analyze", methods=["POST"])
+def analyze():
+    data = request.get_json(force=True)
+    tickers = data.get("tickers", [])
+    weights = data.get("weights")
+    benchmark = data.get("benchmark", "SPY")
+
+    if not tickers:
+        return jsonify({"error": "tickers list required"}), 400
+
+    if weights is None:
+        weights = [1 / len(tickers)] * len(tickers)
+    elif len(weights) != len(tickers):
+        return jsonify({"error": "weights length must match tickers"}), 400
+
+    df = yf.download(tickers + [benchmark], period="1y", progress=False)["Adj Close"]
+
+    portfolio_prices = (df[tickers] * weights).sum(axis=1)
+    benchmark_prices = df[benchmark]
+
+    port_metrics = compute_metrics(portfolio_prices)
+    bench_metrics = compute_metrics(benchmark_prices)
+
+    result = {
+        "portfolio": {
+            "cumulative_return": port_metrics[0],
+            "volatility": port_metrics[1],
+            "sharpe_ratio": port_metrics[2],
+        },
+        "benchmark": {
+            "cumulative_return": bench_metrics[0],
+            "volatility": bench_metrics[1],
+            "sharpe_ratio": bench_metrics[2],
+        },
+    }
+
+    return jsonify(result)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -159,3 +159,4 @@ widgetsnbextension==3.6.0
 yfinance==0.1.70
 zipp==3.8.0
 zope.interface==5.4.0
+Flask==2.2.5


### PR DESCRIPTION
## Summary
- add a minimal Flask application for portfolio analysis
- document how to use the Flask service
- include Flask in requirements
- handle News API failures gracefully
- clarify setup and startup steps in the README

## Testing
- `python -m py_compile app.py valueStocks.py Dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_6841100b70848333a7b522b8e7747db0